### PR TITLE
Fixed UnitIdManager's logger to use correct class name

### DIFF
--- a/src/main/game/entities/managers/UnitIdManager.java
+++ b/src/main/game/entities/managers/UnitIdManager.java
@@ -20,7 +20,7 @@ import org.apache.logging.log4j.Logger;
 
 public class UnitIdManager {
 
-    private final static Logger log = LogManager.getLogger(UnitFactory.class);
+    private final static Logger log = LogManager.getLogger(UnitIdManager.class);
 
     // Static limits on unit counts
     private static final Integer MAX_UNIT_COUNT = 25;


### PR DESCRIPTION
UnitIdManager's logger was using incorrect class name reference. Quick one line change.